### PR TITLE
Adding Asciidoc format to list of known extensions.

### DIFF
--- a/src/req.cpp
+++ b/src/req.cpp
@@ -107,6 +107,10 @@ ReqFileConfig::SortMode ReqFileConfig::getSortMode(const std::string &text)
 ReqFileType ReqFileConfig::getFileType(const std::string &extension)
 {
     if (0 == strcasecmp(extension.c_str(), "txt")) return RF_TEXT;
+    else if (0 == strcasecmp(extension.c_str(), "ad")) return RF_TEXT;
+    else if (0 == strcasecmp(extension.c_str(), "adoc")) return RF_TEXT;
+    else if (0 == strcasecmp(extension.c_str(), "asc")) return RF_TEXT;
+    else if (0 == strcasecmp(extension.c_str(), "asciidoc")) return RF_TEXT;
     else if (0 == strcasecmp(extension.c_str(), "odt")) return RF_ODT;
     else if (0 == strcasecmp(extension.c_str(), "docx")) return RF_DOCX;
     else if (0 == strcasecmp(extension.c_str(), "xslx")) return RF_XSLX;


### PR DESCRIPTION
Hello I am using reqflow with Asciidoc document type.
It is a text file based cocument format a litle bit like LaTeX but simpler.
The file extensions are often either directly .txt, .ad, .adoc, .asc or .asciidoc.
Then I have just add those extension as treated like text files.
In the hope it can be usefull to someone else.

Thank you.