### PR TITLE
Fix constness of comparison operator functors

### DIFF
--- a/src/req.cpp
+++ b/src/req.cpp
@@ -70,7 +70,7 @@ void printErrors()
     }
 }
 
-bool ReqCompare::operator()(const Requirement *a, const Requirement *b)
+bool ReqCompare::operator()(const Requirement *a, const Requirement *b) const
 {
     if (!a) {
         LOG_ERROR("null a in ReqCompare");

--- a/src/req.h
+++ b/src/req.h
@@ -40,7 +40,7 @@ enum ReqFileType { RF_TEXT, RF_ODT, RF_DOCX, RF_XSLX, RF_DOCX_XML, RF_HTML, RF_P
   */
 struct ReqCompare
 {
-    bool operator()(const Requirement *a, const Requirement *b);
+    bool operator()(const Requirement *a, const Requirement *b) const;
 };
 
 struct ReqFileConfig {

--- a/src/stringTools.cpp
+++ b/src/stringTools.cpp
@@ -187,7 +187,7 @@ std::string replaceAll(const std::string &in, char c, const char *replaceBy)
   * REQ_3.17
   *
   */
-bool stringCompare::operator()(const std::string &s1, const std::string &s2)
+bool stringCompare::operator()(const std::string &s1, const std::string &s2) const
 {
 	enum mode_t { STRING, NUMBER } mode = STRING;
 	const char *l = s1.c_str();

--- a/src/stringTools.h
+++ b/src/stringTools.h
@@ -37,7 +37,7 @@ std::string replaceAll(const std::string &in, char c, const char *replaceBy);
 bool stringLessThan(std::string const &s1, std::string const &s2);
 struct stringCompare
 {
-    bool operator()(const std::string &s1, const std::string &s2);
+    bool operator()(const std::string &s1, const std::string &s2) const;
 };
 std::string escapeCsv(const std::string &input);
 


### PR DESCRIPTION
Hi!
My decent compiler's STL (g++ (GCC) 12.2.1 20230201) is a little picky on the constness of comparison operator functors. For example, here:
```
src/req.cpp:270:48:   required from here
/usr/include/c++/12.2.1/bits/stl_tree.h:770:15: error: static assertion failed: comparison object must be invocable as const
  770 |               is_invocable_v<const _Compare&, const _Key&, const _Key&>,
```
I fixed the two functor classes' operators that I could find.
Enjoy!
Max